### PR TITLE
Implemented .md files(bot messages) usage from bot project directory

### DIFF
--- a/.github/applicant-welcome.md
+++ b/.github/applicant-welcome.md
@@ -1,0 +1,5 @@
+Thanks for applying to CHAOSS Badging.
+
+Make sure that you have:
+  - Read through [Event submission requirements](https://github.com/badging/event-diversity-and-inclusion/blob/master/submission/requirements.md) and [guidelines](https://github.com/badging/event-diversity-and-inclusion/blob/master/submission/guidelines.md).
+  - Understood your [role](https://github.com/badging/diversity-and-inclusion/blob/master/roles/applicant.md) as a CHAOSS Badging applicant.

--- a/.github/checklist-virtual.md
+++ b/.github/checklist-virtual.md
@@ -1,0 +1,41 @@
+# Event Review Checklist
+
+
+## Initial checks
+
+- [ ] Event is about Open Source technologies and systems.
+- [ ] Event information is publicly available on a website.x
+- [ ] The Event Code of Conduct is publicly available.
+- [ ] The applicant is the organizer of the event.
+
+💡 ``` Make sure all the initial checks are marked before proceeding with Metric based checks```
+
+## Metric based checks
+
+### Event Demographics
+- [ ] **Measuring Demographics** - The Event has a process for measuring demographics.
+- [ ] **Opt-Out** - The Event provides an opportunity to opt-out of providing demographic data
+- [ ] **Text Input** - The Event provides a text box to input certain data such as Gender, Race, or Ethnicity
+
+### Inclusive Experience at Event
+- [ ] **Speaker Inclusivity** - The Event requests feedback from speakers regarding Diversity & Inclusion.
+- [ ] **Attendee Inclusivity** - The Event requests feedback from attendees regarding Diversity & Inclusion.
+- [ ] **Retention** - The Event incorporates feedback from past events, or has a strategy to incorporate feedback into future iterations of the event.
+- [ ] **Accessibility Requests** - Attendees are able to inquire if accomodations are available and make suggestions for future accomodations at events.
+- [ ] **Session Accessibility** - Event attendees are able to access the event platform after the event
+    
+### Time Inclusion for Virtual Events
+- [ ] **Pre-Recording** - Speakers have the ability to pre-record presentations.
+- [ ] **Network Bandwidth Options** - Attendees are provided with more than one option for video playback quality.
+
+### Code of Conduct at Event
+- [ ] **Findability** - It is possible to find the Code of Conduct on the Event website.
+- [ ] **Clarity** - Event Code of Conduct provides a definition of expected behaviour.
+- [ ] **Reporting venue** - The event has a venue for reporting violations of the CoC at the event website.
+- [ ] **Support at Event** - The Event Code of Conduct provided information about possible methods to provide support to victims of inappropriate behavior.
+- [ ] **Enforcement** - The participants in the Event are required to accept the Code of Conduct.
+
+### Diversity Access tickets
+- [ ] **Availability** - The event provides one or more Diversity Access Tickets.
+- [ ] **Ticket allocation** - The Event has a process for allocating diversity access tickets.
+- [ ] **Findability** - The information about Diversity Access Tickets is public.

--- a/.github/checklist.md
+++ b/.github/checklist.md
@@ -1,0 +1,41 @@
+# Event Review Checklist
+
+
+## Initial checks
+
+- [ ] Event is about Open Source technologies and systems.
+- [ ] Event information is publicly available on a website.x
+- [ ] The Event Code of Conduct is publicly available.
+- [ ] The applicant is the organizer of the event.
+
+💡 ``` Ensure all the initial checks are marked before proceeding with Metric based checks```
+
+## Metric based checks
+
+### Event Demographics
+- [ ] **Measuring Demographics** - The Event has a process for measuring demographics.
+- [ ] **Opt-Out** - The Event provides an opportunity to opt-out of providing demographic data
+- [ ] **Text Input** - The Event provides a text box to input variable demographics such as Gender, Race, or Ethnicity
+
+### Inclusive Experience at Event
+- [ ] **Speaker Inclusivity** - The Event requests feedback from speakers regarding Diversity & Inclusion.
+- [ ] **Attendee Inclusivity** - The Event requests feedback from attendees regarding Diversity & Inclusion.
+- [ ] **Retention** - The Event incorporates feedback from past events, or has a strategy to incorporate feedback into future iterations of the event.
+- [ ] **Accessibility Requests** - Attendees are able to inquire if accomodations are available and make suggestions for future accomodations at events.
+- [ ] **Session Accessibility** - Event attendees are able to access the event platform after the event
+
+### Code of Conduct at Event
+- [ ] **Findability** - It is possible to find the Code of Conduct on the Event website.
+- [ ] **Clarity** - Event Code of Conduct provides a definition of expected behaviour.
+- [ ] **Reporting venue** - The event has a venue for reporting violations of the CoC at the event website.
+- [ ] **Support at Event** - The Event Code of Conduct provided information about possible methods to provide support to victims of inappropriate behavior.
+- [ ] **Enforcement** - The participants in the Event are required to accept the Code of Conduct.
+
+### Diversity Access tickets
+- [ ] **Availability** - The event provides one or more Diversity Access Tickets.
+- [ ] **Ticket allocation** - The Event has a process for allocating diversity access tickets.
+- [ ] **Findability** - The information about Diversity Access Tickets is public.
+
+### Family Friendliness
+- [ ] **Availability** - The Event provides one or more services/facilities for families.
+- [ ] **Findability** - The information about the family friendly services provided at the Event is easy to find on the website.

--- a/.github/moderators.md
+++ b/.github/moderators.md
@@ -1,0 +1,3 @@
+<!--Username list of moderators-->
+
+- Nebrethar

--- a/.github/reviewer-welcome.md
+++ b/.github/reviewer-welcome.md
@@ -1,0 +1,10 @@
+Thank you for becoming a part of this Event Badging review.
+
+Make sure you have looked into the following documents:
+  - [Reviewer guide](https://github.com/badging/diversity-and-inclusion/blob/master/reviewer-guide.md)
+  - [Reviewer role](https://github.com/badging/diversity-and-inclusion/blob/master/roles/reviewer.md)
+  - [Submission guidelines](https://github.com/badging/event-diversity-and-inclusion/blob/master/submission/guidelines.md)(In order to get familiar with applicant actions)
+
+In order to avoid receiving excessive notifications from this repository, set your subscription status to `Not Watching`.
+
+---

--- a/.github/reviewers.md
+++ b/.github/reviewers.md
@@ -1,0 +1,9 @@
+# Reviewer List
+<!--Please add your GitHub username below while applying to be a reviewer-->
+- Ruth-ikegah
+- tetris4
+- Anita-ihuman
+- djmitche
+- germonprez
+- InquisitiveVi
+- Gemarodri

--- a/README.md
+++ b/README.md
@@ -1,18 +1,46 @@
-# badging-bot
+# Badging-bot
+The `@badging-bot,` is a GitHub App that helps to coordinate the workflow of the [D&I Badging](https://handbook.chaoss.community/community-handbook/badging/overview), a peer-review program that is managed by the [CHAOSS Community](https://handbook.chaoss.community/community-handbook/). The main function of the badging-bot is to improve the efficiency of the review process of badging applications with some automated integration. 
 
-## About
+The badging-bot is built around the Journal of Open Source Software [peer review system](https://joss.readthedocs.io/en/latest/) and is used to facilitate the application process for earning DEI event badges.
 
-This is a bot made for helping out with CHAOSS D&I Badging reviews.
+### Functions
+The badging-bot is specifically intended to:
+* Guide applicants/reviewers
+* Assign reviewers for a submission
+* Open checklists for reviewers according to the type of event
+* Check current badge status
+* Generate the final badge link
+* Close an application issue when an application is finalized
 
-## Installation
+## Tasks
+The badging bot can be used for a specific set of tasks:
 
-Visit the public page [here](https://github.com/apps/badging-bot) to install this App on one of your own repositories.
+* When a new submission is created. Once the issue of a new submission is successfully initiated, `@badging-bot` will do three things:
+  * greet the applicant and provide guiding information \([see example](https://github.com/badging/event-diversity-and-inclusion/issues/46#issuecomment-674938374)\)
+  * assign reviewers (In progress!)
+  * open a checklist for each assigned reviewer \([see example](https://github.com/badging/event-diversity-and-inclusion/issues/46#issuecomment-674938396)\)
+* When a command is typed in a review issue comment.
+When someone creates an issue comment with a command, the bot will be triggered and respond in a new comment. This is generally used for generating badges
+* When the state of the review changes
+The bot responds to state changes by managing labels and by opening or closing the issue.
 
-## Bot Function
 
-- Posts contents of `.github/applicant-welcome.md` when an issue is opened
-- Posts contents of `.github/reviewer-welcome.md` + `.github/checklist.md` when a issue is assigned
-- Attaches label `review-begin` when the issue gets two assignees
-- Command `/result` is used to calculate which badge is fit for the application according to review checklists
-- Command `/help` uses the content of `.github/review-help.md` and posts it as comment
-- Command `/end` assigns label `review-end` to the issue
+## Reporting Bugs and Issues
+In case of any bugs, issues and glitches, feel free to open up a GitHub Issue or talk to the community on one of our [communication channels](https://chaoss.community/participate/).
+
+
+## How to contribute
+The badging bot is a result of open source contributions. We don’t take any contribution for granted. We appreciate contributions to documentation, codebase and reviews. 
+Our documentation is a section of the CHAOSS community handbook found [here](https://handbook.chaoss.community/community-handbook/badging/overview). For contributions to documentation, please submit a pull request to the [community handbook repository](https://www.google.com/url?sa=t&source=web&rct=j&url=https://github.com/chaoss/community-handbook&ved=2ahUKEwiBxqfM4rj2AhUDNn0KHUxMAdoQFnoECAMQAQ&usg=AOvVaw3VD3BYnkDUeeDtkYI0F4gD).
+To contribute code to the badging-bot codebase, please read our [contribution guidelines](https://handbook.chaoss.community/community-handbook/contributing/design) and submit a pull request to this repository.
+
+## Credits
+  * [Aastha Bist](https://github.com/bistaastha) - Original Developer of the Badging Bot
+  * [Ore-Aruwaji Oloruntola](https://github.com/thecraftman) - Developed Badging and CHAOSS translation tooling
+  * [Xiaoya Xia Esther](https://github.com/xiaoya-Esther) - Created the initial badging documentation
+  * [Ayush Tamra](https://github.com/ayushtamra) - Developing updates and fixes for the badging-bot
+  * [Enoch Kaxada](https://github.com/kaxada) - Developing updates and fixes for the badging-bot
+  * [Matt Cantu Snell](https://github.com/Nebrethar) - Founder of the DEI Badging initiative
+
+## License
+[ISC License](https://github.com/badging/badging-bot/blob/glitch/LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "list-bot-test",
+  "name": "badging-bot",
   "version": "1.0.0",
   "private": true,
-  "description": "A Probot app",
+  "description": "A github app that automates some of the portions of the review process workflow for CHAOSS DEI Badging applications",
   "author": "Aastha Bist <abist119@gmail.com>",
   "license": "ISC",
-  "repository": "https://github.com/bistaastha/list-bot-test.git",
-  "homepage": "https://github.com/bistaastha/list-bot-test",
-  "bugs": "https://github.com/bistaastha/list-bot-test/issues",
+  "repository": "https://github.com/badging/badging-bot.git",
+  "homepage": "https://github.com/badging/badging-bot",
+  "bugs": "https://github.com/badging/badging-bot/issues",
   "keywords": [
     "probot",
     "github",

--- a/src/postChecklist.js
+++ b/src/postChecklist.js
@@ -4,17 +4,17 @@ function postChecklist(context) {
 
   var fs = require('fs');
 
-
+  // Welcome message for reviewers
   var reviewerWelcome = fs.readFileSync("./.github/reviewer-welcome.md", "utf8")
 
 
   const title = context.payload.issue.title;
 
-
+  // Review checklist
   var checklist = fs.readFileSync("./.github/checklist.md", "utf8")
 
 
-
+  // Review checklist for virtual events
   if (title.substring(0, 15) == "[Virtual Event]") {
 
     checklist = fs.readFileSync("./.github/checklist-virtual.md", "utf8")

--- a/src/postChecklist.js
+++ b/src/postChecklist.js
@@ -1,30 +1,32 @@
-async function postChecklist(context) {
+function postChecklist(context) {
   const heading = `# Checklist for @${context.payload.assignee.login}`;
 
-  const reviewerWelcome = await context.github.repos.getContents(
-    context.repo({ path: ".github/reviewer-welcome.md" })
-  );
+
+  var fs2 = require('fs');
+
+
+  var reviewerWelcome = fs2.readFileSync("./.github/reviewer-welcome.md", "utf8")
+
 
   const title = context.payload.issue.title;
 
-  let checklist = await context.github.repos.getContents(
-    context.repo({ path: ".github/checklist.md" })
-  );
+
+  var checklist = fs2.readFileSync("./.github/checklist.md", "utf8")
+
+
 
   if (title.substring(0, 15) == "[Virtual Event]") {
-    checklist = await context.github.repos.getContents(
-      context.repo({ path: ".github/checklist-virtual.md" })
-    );
+
+    checklist = fs2.readFileSync("./.github/checklist-virtual.md", "utf8")
+
   }
 
-  const reviewerMessage =
-    heading +
-    "\n" +
-    Buffer.from(reviewerWelcome.data.content, "base64").toString() +
-    Buffer.from(checklist.data.content, "base64").toString();
-  console.log(reviewerMessage);
+  // Final reviewer message
+  var reviewerMessage = heading + "\n" + reviewerWelcome + checklist;
 
-  context.github.issues.createComment(context.issue({ body: reviewerMessage }));
+  context.github.issues.createComment(
+    context.issue({ body: reviewerMessage })
+  );
 
   if (context.payload.issue.assignees.length == 2) {
     context.github.issues.addLabels(

--- a/src/postChecklist.js
+++ b/src/postChecklist.js
@@ -2,22 +2,22 @@ function postChecklist(context) {
   const heading = `# Checklist for @${context.payload.assignee.login}`;
 
 
-  var fs2 = require('fs');
+  var fs = require('fs');
 
 
-  var reviewerWelcome = fs2.readFileSync("./.github/reviewer-welcome.md", "utf8")
+  var reviewerWelcome = fs.readFileSync("./.github/reviewer-welcome.md", "utf8")
 
 
   const title = context.payload.issue.title;
 
 
-  var checklist = fs2.readFileSync("./.github/checklist.md", "utf8")
+  var checklist = fs.readFileSync("./.github/checklist.md", "utf8")
 
 
 
   if (title.substring(0, 15) == "[Virtual Event]") {
 
-    checklist = fs2.readFileSync("./.github/checklist-virtual.md", "utf8")
+    checklist = fs.readFileSync("./.github/checklist-virtual.md", "utf8")
 
   }
 

--- a/src/postWelcome.js
+++ b/src/postWelcome.js
@@ -1,8 +1,8 @@
 async function postWelcome(context) {
 
-  var fs1 = require('fs');
+  var fs = require('fs');
 
-  var applicantWelcome = fs1.readFileSync("./.github/applicant-welcome.md", "utf8")
+  var applicantWelcome = fs.readFileSync("./.github/applicant-welcome.md", "utf8")
 
 
   context.github.issues.createComment(

--- a/src/postWelcome.js
+++ b/src/postWelcome.js
@@ -1,15 +1,12 @@
 async function postWelcome(context) {
-  const applicantWelcome = await context.github.repos.getContents(
-    context.repo({ path: ".github/applicant-welcome.md" })
-  );
 
-  const applicantMessage = Buffer.from(
-    applicantWelcome.data.content,
-    "base64"
-  ).toString();
+  var fs1 = require('fs');
+
+  var applicantWelcome = fs1.readFileSync("./.github/applicant-welcome.md", "utf8")
+
 
   context.github.issues.createComment(
-    context.issue({ body: applicantMessage })
+    context.issue({ body: applicantWelcome })
   );
 }
 

--- a/src/postWelcome.js
+++ b/src/postWelcome.js
@@ -2,6 +2,7 @@ async function postWelcome(context) {
 
   var fs = require('fs');
 
+  // Welcome message for the applicants
   var applicantWelcome = fs.readFileSync("./.github/applicant-welcome.md", "utf8")
 
 


### PR DESCRIPTION
1. Implemented [project idea](https://github.com/orgs/badging/projects/1#card-79627246)
2. Added the new README.md

**Implementation:**
Bot updated to send messages(welcome messages and checklists) from badging bot project directory in place of using messages from event-diversity-and inclusion repository.

See example implementation [here](https://github.com/ayushtamra/event-diversity-and-inclusion/issues/63)