### PR TITLE
Added a manifest file - app.yml, for initial configuration of app

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -1,0 +1,137 @@
+# This is a GitHub App Manifest. These settings will be used by default when
+# initially configuring your GitHub App.
+#
+# NOTE: changing this file will not update your GitHub App settings.
+# You must visit github.com/settings/apps/your-app-name to edit them.
+#
+# Read more about configuring your GitHub App:
+# https://probot.github.io/docs/development/#configuring-a-github-app
+#
+# Read more about GitHub App Manifests:
+# https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/
+
+# The list of events the GitHub App subscribes to.
+# Uncomment the event names below to enable them.
+default_events:
+  # - check_run
+  # - check_suite
+  # - commit_comment
+  # - create
+  # - delete
+  # - deployment
+  # - deployment_status
+  # - fork
+  # - gollum
+  - issue_comment
+  - issues
+  # - label
+  # - milestone
+  # - member
+  # - membership
+  # - org_block
+  # - organization
+  # - page_build
+  # - project
+  # - project_card
+  # - project_column
+  # - public
+  - pull_request
+  # - pull_request_review
+  # - pull_request_review_comment
+  # - push
+  # - release
+  - repository
+  # - repository_import
+  # - status
+  # - team
+  # - team_add
+  # - watch
+
+# The set of permissions needed by the GitHub App. The format of the object uses
+# the permission name for the key (for example, issues) and the access type for
+# the value (for example, write).
+# Valid values are `read`, `write`, and `none`
+default_permissions:
+  # Repository creation, deletion, settings, teams, and collaborators.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-administration
+  administration: read
+
+  # Checks on code.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-checks
+  # checks: read
+
+  # Repository contents, commits, branches, downloads, releases, and merges.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-contents
+  contents: write
+
+  # Deployments and deployment statuses.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-deployments
+  # deployments: read
+
+  # Issues and related comments, assignees, labels, and milestones.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-issues
+  issues: write
+
+  # Search repositories, list collaborators, and access repository metadata.
+  # https://developer.github.com/v3/apps/permissions/#metadata-permissions
+  metadata: read
+
+  # Retrieve Pages statuses, configuration, and builds, as well as create new builds.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-pages
+  # pages: read
+
+  # Pull requests and related comments, assignees, labels, milestones, and merges.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-pull-requests
+  pull_requests: write
+
+  # Manage the post-receive hooks for a repository.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-repository-hooks
+  # repository_hooks: read
+
+  # Manage repository projects, columns, and cards.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-repository-projects
+  # repository_projects: read
+
+  # Retrieve security vulnerability alerts.
+  # https://developer.github.com/v4/object/repositoryvulnerabilityalert/
+  # vulnerability_alerts: read
+
+  # Commit statuses.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-statuses
+  # statuses: read
+
+  # Organization members and teams.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-members
+  # members: read
+
+  # View and manage users blocked by the organization.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-organization-user-blocking
+  # organization_user_blocking: read
+
+  # Manage organization projects, columns, and cards.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-organization-projects
+  # organization_projects: read
+
+  # Manage team discussions and related comments.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-team-discussions
+  # team_discussions: read
+
+  # Manage the post-receive hooks for an organization.
+  # https://developer.github.com/v3/apps/permissions/#permission-on-organization-hooks
+  # organization_hooks: read
+
+  # Get notified of, and update, content references.
+  # https://developer.github.com/v3/apps/permissions/
+  # organization_administration: read
+# The name of the GitHub App. Defaults to the name specified in package.json
+# name: My Probot App
+
+# The homepage of your GitHub App.
+# url: https://example.com/
+
+# A description of the GitHub App.
+# description: A description of my awesome app
+
+# Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
+# Default: true
+# public: false


### PR DESCRIPTION
This pull request resolves the issue number #6 

Now while registering the application on Github for testing on a personal account, now user don't have to manually change permissions on their settings page after installation.

Now it asks for the permissions during installation to the user, to make the github app work :100: 

Screenshot:
![Screenshot from 2022-04-14 01-48-50](https://user-images.githubusercontent.com/64156683/163267993-811c5310-62c3-451a-b805-42b8935a70ac.png)

Also the app works well, see example [here](https://github.com/ayushtamra/event-diversity-and-inclusion/issues/66#issuecomment-1098451364)